### PR TITLE
Fix tiny error

### DIFF
--- a/Worker.php
+++ b/Worker.php
@@ -1936,7 +1936,7 @@ class Worker
             }
 
             \file_put_contents(static::$_statisticsFile, \serialize($all_worker_info)."\n", \FILE_APPEND);
-            $loadavg = \function_exists('sys_getloadavg') ? \array_map('round', \sys_getloadavg(), array(2)) : array('-', '-', '-');
+            $loadavg = \function_exists('sys_getloadavg') ? \array_map('round', \sys_getloadavg(), array(2,2,2)) : array('-', '-', '-');
             \file_put_contents(static::$_statisticsFile,
                 "----------------------------------------------GLOBAL STATUS----------------------------------------------------\n", \FILE_APPEND);
             \file_put_contents(static::$_statisticsFile,


### PR DESCRIPTION
because of `sys_getloadavg()` return `array(3)`
in **PHP8+** an error will ocurr like:
`round(): Argument #2 ($precision) must be of type int, null given`